### PR TITLE
Standalone

### DIFF
--- a/src/org/adw/launcher/MyLauncherSettings.java
+++ b/src/org/adw/launcher/MyLauncherSettings.java
@@ -286,6 +286,9 @@ public class MyLauncherSettings extends PreferenceActivity implements OnPreferen
 		intent.addCategory("android.intent.category.DEFAULT");
 		PackageManager pm=getPackageManager();
 		List<ResolveInfo> themes=pm.queryIntentActivities(intent, 0);
+		intent=new Intent("org.adw.launcher.THEMES.DYNAMIC");
+		intent.addCategory("android.intent.category.DEFAULT");
+		themes.addAll(pm.queryIntentActivities(intent, 0));		
 		String[] entries = new String[themes.size()+1];
 		String[] values = new String[themes.size()+1];
 		entries[0]=Launcher.THEME_DEFAULT;


### PR DESCRIPTION
This update adds handling for dynamic icon packs like Droidicon and Tha Icon Ultimate.  It adds an intent filter for org.adw.launcher.THEMES.DYNAMIC.  It also handles querying the content provider at x.x.x.provider.DynamicIconsProvider for a FileInputStream that can be read into a Bitmap.
